### PR TITLE
Fixed server down cause node-red to close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ coverage/
 .nyc_output/
 .idea/
 .log
+nodered-data/
 
 package-lock.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Node-RED with Custom Node",
+      "runtimeExecutable": "node-red",
+      "args": ["-u", "${workspaceFolder}/nodered-data"],
+      "cwd": "${workspaceFolder}",
+      "runtimeArgs": ["--inspect-brk"],
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Global Node-RED",
+      "runtimeExecutable": "node-red",
+      "args": ["-v", "-u", "${workspaceFolder}/nodered-data"],
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "NODE_ENV": "development"
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "runtimeArgs": ["--inspect-brk"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AMQP nodes for node-red
 Install via the Palette Manager or from within your node-red directory (typically `~/.node-red`) run:
 
 ```
-npm i @stormpass/node-red-contrib-amqp
+npm i @beantech/node-red-contrib-amqp
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@stormpass/node-red-contrib-amqp",
+  "name": "@beantech/node-red-contrib-amqp",
   "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@stormpass/node-red-contrib-amqp",
+      "name": "@beantech/node-red-contrib-amqp",
       "version": "1.4.1",
       "license": "ISC",
       "dependencies": {
-        "@stormpass/node-red-contrib-amqp": "file:",
+        "@beantech/node-red-contrib-amqp": "file:",
         "amqplib": "^0.10.3",
         "lodash.clonedeep": "^4.5.0",
         "uuid": "^8.3.2"
@@ -345,6 +345,10 @@
         "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "node_modules/@beantech/node-red-contrib-amqp": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -1528,10 +1532,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
-    },
-    "node_modules/@stormpass/node-red-contrib-amqp": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@stormpass/node-red-contrib-amqp",
+  "name": "@beantech/node-red-contrib-amqp",
   "license": "ISC",
   "version": "1.4.1",
   "description": "Amqp nodes for node-red",
@@ -73,7 +73,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "@stormpass/node-red-contrib-amqp": "file:",
+    "@beantech/node-red-contrib-amqp": "file:",
     "amqplib": "^0.10.3",
     "lodash.clonedeep": "^4.5.0",
     "uuid": "^8.3.2"


### PR DESCRIPTION
If the rabbitMQ server goes down the node enter in error state and cause node-red to shutdown. This fix this issues.